### PR TITLE
Updated to a more secure email verification process

### DIFF
--- a/prisma/migrations/20250824205822_init_pending_signup/migration.sql
+++ b/prisma/migrations/20250824205822_init_pending_signup/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `emailVerified` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the `VerificationToken` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "emailVerified";
+
+-- DropTable
+DROP TABLE "VerificationToken";
+
+-- CreateTable
+CREATE TABLE "PendingSignup" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PendingSignup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PendingSignup_token_key" ON "PendingSignup"("token");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,17 +15,18 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  email         String    @unique
-  password      String
-  emailVerified DateTime?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  id        String   @id @default(cuid())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
-model VerificationToken {
-  id         String   @id @default(cuid())
-  token      String   @unique
-  identifier String // usually the email
-  expires    DateTime
+model PendingSignup {
+  id        String   @id @default(cuid())
+  email     String
+  password  String
+  token     String   @unique
+  expires   DateTime
+  createdAt DateTime @default(now())
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -22,9 +22,10 @@ export const authOptions: NextAuthOptions = {
           where: { email: credentials.email },
         });
 
-        if (!user) throw new Error("No user found");
-        if (!user.emailVerified)
-          throw new Error("Please verify your email before logging in.");
+        if (!user)
+          throw new Error(
+            "No user found. Please verify your email before logging in."
+          );
 
         const isValid = await compare(credentials.password, user.password);
         if (!isValid) throw new Error("Invalid password");

--- a/src/app/api/auth/resend/route.ts
+++ b/src/app/api/auth/resend/route.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from "@prisma/client";
+import { compare } from "bcryptjs";
+import { randomBytes } from "crypto";
+import { addHours } from "date-fns";
+import { NextResponse } from "next/server";
+import { sendEmailVerification } from "@/lib/utils/email";
+
+const prisma = new PrismaClient();
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json();
+
+  if (!email || !password)
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+
+  const pendingRecords = await prisma.pendingSignup.findMany({
+    where: { email },
+  });
+
+  let matched: { id: string } | null = null;
+
+  for (const record of pendingRecords) {
+    const isMatch = await compare(password, record.password);
+    if (isMatch) {
+      matched = { id: record.id };
+      break;
+    }
+  }
+
+  if (!matched)
+    return NextResponse.json(
+      { error: "No matching pending record found" },
+      { status: 404 }
+    );
+
+  const newToken = randomBytes(32).toString("hex");
+
+  const updated = await prisma.pendingSignup.update({
+    where: { id: matched.id },
+    data: {
+      token: newToken,
+      expires: addHours(new Date(), 1),
+    },
+  });
+
+  await sendEmailVerification(updated.email, newToken);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -43,21 +43,15 @@ export async function POST(req: Request) {
 
     const hashedPassword = await hash(password, 10);
 
-    const user = await prisma.user.create({
-      data: {
-        email,
-        password: hashedPassword,
-      },
-    });
-
     // Creating email verification token and url
     const token = randomBytes(32).toString("hex");
 
-    await prisma.verificationToken.create({
+    await prisma.pendingSignup.create({
       data: {
-        identifier: email,
+        email,
+        password: hashedPassword,
         token,
-        expires: addHours(new Date(), 1), // valid for 1 hour
+        expires: addHours(new Date(), 1),
       },
     });
 


### PR DESCRIPTION
- changed the user table, removing the verified field:
      - >no longer needed. User will only be created after email is verified.

- added a pending table :
     - >on sign up, a pending record with the given credentials and a token is stored here

- migrated the changes to the db

- updated these routes to reflect the db changes:
     ->/src/app/api/signup/route.ts 
     ->/src/app/api/verify-email/route.ts 

- added a route for requesting a new verification link (in the case of lost or expired links):
     ->/src/app/api/resend/route.ts 


 Core Behavioral Rules:
🟢 Users only exist in the User table after email verification
🔒 Attackers cannot override or preempt the real user's password
📬 Resending a token requires knowledge of the original password
🧼 Expired or old PendingSignup records are:
	-Ignored on verification
	-Cleaned up periodically (e.g. >7 days old)  - to be added
