### PR TITLE
Added anti-bloat and validation to some auth routes that needed it

### DIFF
--- a/prisma/migrations/20250825161917_tracking_pending_table_updates/migration.sql
+++ b/prisma/migrations/20250825161917_tracking_pending_table_updates/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `PendingSignup` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "PendingSignup" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,4 +29,5 @@ model PendingSignup {
   token     String   @unique
   expires   DateTime
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/src/app/api/auth/resend/route.ts
+++ b/src/app/api/auth/resend/route.ts
@@ -3,7 +3,9 @@ import { compare } from "bcryptjs";
 import { randomBytes } from "crypto";
 import { addHours } from "date-fns";
 import { NextResponse } from "next/server";
+
 import { sendEmailVerification } from "@/lib/utils/email";
+import { isValidEmail, isStrongPassword } from "@/lib/utils/validation";
 
 const prisma = new PrismaClient();
 
@@ -12,6 +14,10 @@ export async function POST(req: Request) {
 
   if (!email || !password)
     return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+
+  if (!isValidEmail(email) || !isStrongPassword(password)) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 400 });
+  }
 
   const pendingRecords = await prisma.pendingSignup.findMany({
     where: { email },

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: Request) {
     },
   });
 
-  await prisma.pendingSignup.delete({ where: { token } });
+  await prisma.pendingSignup.deleteMany({ where: { email: pending.email } });
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
Updates:
- api/auth/verify-email/route.ts
	-> updated the route to delete every pending record with the given email as a value once the given email has been verified, instead of just deleting the record that matches the given token
- api/auth/resend/route.ts
	-> added validation checks to email and password inputs (reason here)
- schema.prisma
	-> added the updatedAt field in the pending table to track when updates happen (for housekeeping reasons, might utilize this in the future)

To do:
- will look into cron jobs to delete dead pending records in deployment
	-> apparently you can run cron jobs in development using node-cron - usually used to test them
	-> in deployment they are typically configured on the hosting platform or server
		e.g. 	vercel - Edge or serverless functions + 3rd-party cron scheduler (e.g., Upstash, GitHub Actions, or external cron trigger)
		    	render - Built-in cron job support

- need to add client side page for resend route
- need to look into rate limiting in next js
- need to add forgot password, reset password, delete account and log out functionalities
- will add nav bar after all of this is completed