### PR TITLE
Added resend-verification client side page

### DIFF
--- a/src/app/resend-verification/page.tsx
+++ b/src/app/resend-verification/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+
+import { isValidEmail, isStrongPassword } from "@/lib/utils/validation";
+
+export default function ResendPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleResend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage("");
+    setError("");
+
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email.");
+      return;
+    }
+
+    if (!isStrongPassword(password)) {
+      setError("Please enter a valid password.");
+      return;
+    }
+
+    setLoading(true);
+
+    const res = await fetch("/api/auth/resend", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    });
+
+    const data = await res.json();
+    setLoading(false);
+
+    if (res.ok) {
+      setMessage("Verification email sent! Please check your inbox.");
+    } else {
+      setError(data.error || "Something went wrong. Try again.");
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto py-10 px-4">
+      <h1 className="text-2xl font-bold mb-4 text-center">
+        Resend Verification Email
+      </h1>
+      <form onSubmit={handleResend} className="space-y-4">
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {message && <p className="text-sm text-green-600">{message}</p>}
+
+        <input
+          type="email"
+          placeholder="Email"
+          required
+          className="w-full p-2 border rounded"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+
+        <input
+          type="password"
+          placeholder="Password"
+          required
+          className="w-full p-2 border rounded"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? "Sending..." : "Resend Email"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
- page allows user to request a new verification link to verify their email
- user must log in using the credentials they used at sign up
- their credentials are then sent to the backend api route for resending email verification  /api/auth/resend-verification
- their password is used to search the pending records and compare to the record's stored password
- when a record that matches is found, its token is updated and an new verification with that token is sent to the user's email